### PR TITLE
Customer API docs: add production server + 1.3.0 (Base64 file upload for DOCX/PDF/PPTX/XLSX)

### DIFF
--- a/customer-api/1.2.0.yaml
+++ b/customer-api/1.2.0.yaml
@@ -10,6 +10,8 @@ info:
   version: "1.2.0"
 
 servers:
+  - url: https://api.proofed.com
+    description: Production Environment
   - url: https://stageapi.proofed.com
     description: Staging Environment
 

--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -71,7 +71,7 @@ paths:
               $ref: "#/components/schemas/OrderRequest"
             examples:
               jsonBlockOrder:
-                summary: JSON (Block JSON) order
+                summary: HTML (Block JSON) order
                 value:
                   externalReference: "order-12345"
                   services: ["Proofreading"]

--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -1,0 +1,770 @@
+openapi: 3.0.3
+info:
+  title: Proofed Customer API
+  description: >
+    This API specification enables the automatic creation of Proofed orders directly from partner systems. By integrating with this API, you can eliminate the need for manual order entry, significantly reducing administrative effort and streamlining the editing workflow. For further guidance or support, please contact your Service Delivery Manager.
+
+
+    
+    The Proofed Customer API enables customers to programmatically submit and manage orders for content editing services. This API supports order submission, order retrieval via search or lookup, and provides webhook notifications when an order status changes.
+  version: "1.3.0"
+
+servers:
+  - url: https://api.proofed.com
+    description: Production Environment
+  - url: https://stageapi.proofed.com
+    description: Staging Environment
+
+paths:
+  /clientAPIservice/orders:
+    post:
+      summary: Submit an Order
+      description: >
+        Submits a new order to Proofed's order management system (OMS). 
+
+        ![Order submission sequence diagram](https://raw.githubusercontent.com/Proofed/B2BCustomerDocumentation/main/customer-api/assets/sequence.png)
+
+        Upon successful submission, the order is processed,
+        stored, and assigned a unique `orderId`. Make sure that all mandatory fields are provided and that header authentication
+        details (Api-Key, Organization-Key) and IdempotencyId are included.
+      operationId: submitOrder
+      tags:
+        - Orders
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          schema:
+            type: string
+            enum: [application/json]
+            example: application/json
+          description: Specifies the format of the request payload. Must be `application/json`.
+        - in: header
+          name: Api-Key
+          required: true
+          schema:
+            type: string
+            example: 4900cd44-a855-41ab-a336-78eda2ed5bbe
+          description: A unique Api-Key provided to authenticate requests.
+        - in: header
+          name: Organization-Key
+          required: true
+          schema:
+            type: string
+            example: add8cf22-5afb-4a44-ab36-57b709325c81
+          description: A unique identifier for your organization.
+        - in: header
+          name: IdempotencyId
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 0aa98460-7156-4e48-99b6-909f9a527229
+          description: >
+            A unique identifier for each order submission to ensure message uniqueness and prevent duplicate orders.
+            Use a UUID version 4 (or broader) formatted as 36 characters.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderRequest"
+            examples:
+              jsonBlockOrder:
+                summary: JSON (Block JSON) order
+                value:
+                  externalReference: "order-12345"
+                  services: ["Proofreading"]
+                  deliverySpeed: "Expedited"
+                  platformId: 1
+                  contentType: "Valuation Report"
+                  contentSubject: "Commercial Real Estate"
+                  language: "en-US"
+                  workItemFormat: "JSON"
+                  projectId: 123
+                  workItem:
+                    - name: "Introduction"
+                      type: "html"
+                      content: "<p>Welcome to the introduction.</p>"
+              fileUploadOrder:
+                summary: File upload order (DOCX)
+                value:
+                  externalReference: "order-12346"
+                  services: ["Editing"]
+                  deliverySpeed: "Regular"
+                  platformId: 1
+                  contentType: "Valuation Report"
+                  contentSubject: "Commercial Real Estate"
+                  language: "en-US"
+                  workItemFormat: "DOCX"
+                  workItemIdentity: "Document-1"
+                  projectId: 123
+                  workItem:
+                    - content: "UEsDBBQAAAAIAB1geVyY04HD...(Base64 of the file)...AAAA="
+      responses:
+        "200":
+          description: >
+            **Success** – Order submitted successfully. The response includes the idempotency identifier and Proofed's unique order Id.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderResponse"
+        "400":
+          description: >
+            **Bad Request** – The request was unacceptable because of missing required fields, invalid values, or a duplicate order.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: >
+            **Unauthorized** – The Api-Key or Organization-Key is invalid or missing.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedErrorResponse"
+        "413":
+          description: >
+            **Payload Too Large** – The request payload exceeds the maximum allowed size of 4 MB.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: >
+            **Internal Server Error** – An unexpected error occurred in the API.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerErrorResponse"
+        "503":
+          description: >
+            **Service Unavailable** – The system is down for maintenance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerErrorResponse"
+    get:
+      summary: Search Orders
+      description: >
+        Retrieves a list of orders based on the specified search criteria.
+        Results include only API-entered orders and are restricted to active customers' projects (project ID) at the time of the search.
+        When searching by date range, results are sorted by creation date in descending order.
+        Only orders with statuses 'Live', 'Complete', or 'Canceled' are returned.
+      operationId: searchOrders
+      tags:
+        - Orders
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          schema:
+            type: string
+            enum: [application/json]
+          description: Specifies the format of the request. Must be `application/json`.
+        - in: header
+          name: Api-Key
+          required: true
+          schema:
+            type: string
+          description: Key value required to access Proofed API.
+        - in: header
+          name: Organization-Key
+          required: true
+          schema:
+            type: string
+            maxLength: 50
+          description: >
+            Key value assigned to the Organization required to access the API. Authentication takes place at the Organization level.
+        - in: header
+          name: SearchBy
+          required: true
+          schema:
+            type: string
+            enum: [DateRange, ExternalReference, IdempotencyId]
+          description: The criteria to search by.
+        - in: header
+          name: SearchValue
+          required: true
+          schema:
+            type: string
+          description: >
+            The value to search for. For 'DateRange', this is the start date in YYYY-MM-DD format.
+            For 'ExternalReference' and 'IdempotencyId', it's the corresponding value.
+        - in: header
+          name: SearchValue2
+          required: false
+          schema:
+            type: string
+          description: >
+            Required when 'SearchBy' is 'DateRange'. Specifies the end date in YYYY-MM-DD format.
+            Must be greater than the start date.
+      responses:
+        "200":
+          description: A list of orders matching the search criteria.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
+        "400":
+          description: Bad Request – Invalid search parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized – Invalid or missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedErrorResponse"
+        "500":
+          description: Internal Server Error – An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerErrorResponse"
+  /clientAPIservice/orders/{id}:
+    get:
+      summary: Get Order by ID
+      description: >
+        Retrieves the details of a specific order using its unique order ID.
+        Orders with the following statuses are returned: Complete, Live, Canceled.
+      operationId: getOrderById
+      tags:
+        - Orders
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The unique identifier of the order.
+        - in: header
+          name: Content-Type
+          required: true
+          schema:
+            type: string
+            enum: [application/json]
+          description: Specifies the format of the request. Must be `application/json`.
+        - in: header
+          name: Api-Key
+          required: true
+          schema:
+            type: string
+          description: Key value required to access Proofed API.
+        - in: header
+          name: Organization-Key
+          required: true
+          schema:
+            type: string
+            maxLength: 50
+          description: >
+            Key value assigned to the Organization required to access the API. Authentication takes place at the Organization level.
+      responses:
+        "200":
+          description: The details of the specified order.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderDetail"
+        "400":
+          description: Bad Request – Invalid order ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized – Invalid or missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedErrorResponse"
+        "404":
+          description: Not Found – Order with the specified ID does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error – An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerErrorResponse"
+  /order-callback:
+    post:
+      summary: Order Callback Webhooks
+      description: >
+        This describes the webhook endpoints that you will need to implement on your system to receive order status updates from Proofed.
+        When the API backend completes specific order actions (e.g., order creation, completion, or cancellation),
+        Proofed will send a POST request to your webhook URL with details about the order.
+
+        You will need to provide your webhook URL during the onboarding process.
+
+        **Important:**
+
+        - Your endpoint must return an HTTP 200 status code to acknowledge receipt of the webhook.
+
+        - If the webhook payload received from Proofed is invalid, return a 400 status code.
+
+        - If the webhook request's Api-Key is not authorized, return a 401 status code.
+
+        - The Proofed system may retry the webhook if it receives other bad status codes (e.g., 5xx).
+
+        - In case of an issue while processing the order, the `message` field will contain: "exception: [Error={error}] [InvocationId={id}]".
+
+
+        **Webhook Types:**
+
+        
+        - **Order Created:** Notifies when an order is successfully created.
+
+        
+        - **Order Complete:** Notifies when an order is completed (in development, not yet deployed).
+
+        
+        - **Order Canceled:** Notifies when an order is canceled (in development, not yet deployed).
+
+        
+      operationId: orderCallback
+      tags:
+        - Webhooks
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          schema:
+            type: string
+            enum: [application/json]
+            example: application/json
+          description: Specifies the format of the request payload. Must be `application/json`.
+        - in: header
+          name: Api-Key
+          required: false
+          schema:
+            type: string
+            example: 4900cd44-a855-41ab-a336-78eda2ed5bbe
+          description: >
+            An optional Api-Key that you can require Proofed to include when calling your webhook URL.
+            This key value is associated with the organization and defined in the organization table.
+            Provide your preferred key during integration if you choose to use this authentication.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderCallback"
+      responses:
+        "200":
+          description: >
+            **Callback received successfully.** Return this status code to indicate that your system has successfully received and acknowledged the webhook.
+        "400":
+          description: >
+            **Bad Request.** Indicates that the callback payload is missing required fields or contains invalid data.
+        "401":
+          description: >
+            **Unauthorized.** Indicates that the provided Api-Key is invalid or not authorized.
+
+components:
+  schemas:
+    OrderRequest:
+      type: object
+      description: >
+        Request payload for submitting an order. All properties marked as **Mandatory** must be provided.
+      required:
+        - externalReference
+        - deliverySpeed
+        - platformId
+        - contentType
+        - contentSubject
+        - language
+        - workItemFormat
+        - projectId
+        - services
+      properties:
+        externalReference:
+          type: string
+          maxLength: 100
+          description: >
+            **Mandatory.** A unique reference provided by your system to correlate orders.
+            This value must be unique for your Organization.
+          example: "order-12345"
+        services:
+          type: array
+          description: >
+            **Mandatory.** An array listing the services requested.
+                        
+            Note: The combination of services must be pre-agreed with Proofed before sending.
+            Requests with non-approved service combinations will result in an error response.
+          items:
+            type: string
+            enum:
+              - Proofreading
+              - Fact-Checking
+              - Editing
+              - Substantive Editing
+              - AI Package
+            example: "Proofreading"
+        deliverySpeed:
+          type: string
+          maxLength: 50
+          description: >
+            **Mandatory.** Specifies the turnaround time for the order.
+            Valid values are project specific but typically include: `Regular`, `Expedited`, and `Rapid`.
+          example: "Expedited"
+        platformId:
+          type: integer
+          description: >
+            **Mandatory.** The platform Id represents the platform where the order will be processed.
+            Valid Ids will be communicated during onboarding.
+          example: 1
+        contentType:
+          type: string
+          maxLength: 50
+          description: >
+            **Mandatory.** The type of content for the order (e.g., "Valuation Report").
+            Proofed will communicate a list of valid subjects during onboarding.
+          example: "Valuation Report"
+        contentSubject:
+          type: string
+          maxLength: 50
+          description: >
+            **Mandatory.** The subject of the document (e.g., "Commercial Real Estate").
+            Proofed will communicate a list of valid subjects during onboarding.
+          example: "Commercial Real Estate"
+        language:
+          type: string
+          maxLength: 10
+          description: >
+            **Mandatory.** Specifies the language and region of the document.
+
+            Format: ISO-639-1 language code followed by ISO-3166-1 region code (e.g., en-US).
+
+            Currently supported languages are:
+            `en-US`, `en-GB`, `en-AU`, `en-CA`
+          example: "en-US"
+        workItemFormat:
+          type: string
+          maxLength: 8
+          description: >
+            **Mandatory.** The format of the work item being submitted.
+
+            Supported values are:
+
+            - `JSON` — Proofed Block JSON content supplied inline in `workItem`.
+
+            - `DOCX`, `PDF`, `PPTX`, `XLSX` — a file uploaded as a Base64-encoded string in `workItem`.
+
+            The set of accepted file formats is controlled by Proofed and confirmed during onboarding; a value outside the supported set is rejected.
+          example: "JSON"
+        projectId:
+          type: integer
+          description: >
+            **Mandatory.** The unique identifier for the project this order belongs to.
+            Valid values will be communicated during onboarding.
+          example: 123
+        workItemIdentity:
+          type: string
+          maxLength: 40
+          description: >
+            **Conditional.** Required when `workItemFormat` is not `JSON` (i.e. for file uploads). Used to construct the stored filename, formed as `workItemIdentity` + `.` + `workItemFormat` (e.g. `Document-1.DOCX`).
+            Valid characters include alphanumeric characters, hyphen (-), and underscore (_).
+          example: "Document-1"
+        workItemStyleName:
+          type: string
+          maxLength: 50
+          description: >
+            Optional. Specifies the style guide name for the order.
+          example: "Modern"
+        workItemStyleGuideUrl:
+          type: string
+          description: >
+            Optional. URL to the style guide applicable for the order.
+          example: "https://example.com/styleguide"
+        workItemStyleIdentifier:
+          type: string
+          description: >
+            Optional. A unique identifier for the style guide to be used.
+            If not provided (or null), the default style guide associated with the organization group will be used.
+          example: "standard-style-01"
+        batchIdentifier:
+          type: string
+          maxLength: 50
+          description: >
+            Optional. A batch identifier used to group related orders.
+          example: "batch-001"
+        purchaseOrderId:
+          type: string
+          maxLength: 50
+          description: >
+            Optional. The accounting purchase order identifier provided by your system. 
+            This ID will be passed through accounting processes and uniquely identifies 
+            each order against the purchase order ID in addition to the external reference.
+          example: "PO-12345"
+        additionalBriefContent:
+          type: string
+          description: >
+            Optional. Additional notes for the editor that describe any specific requests.
+            This text will not be edited.
+          example: "Please review the document for accuracy."
+        workItem:
+          type: array
+          description: >
+            **Mandatory.** The content to be edited. How this array is used depends on `workItemFormat`:
+
+            - **`JSON` (Block JSON):** one or more objects, each representing a section of the content, with a `name`, a `type` (either "text" or "html"), and the `content` itself.
+
+            - **File upload (`DOCX`, `PDF`, `PPTX`, `XLSX`):** exactly one object whose `content` is the Base64-encoded raw bytes of the file (with no data-URI prefix). The `name` and `type` fields are not used for file uploads, and supplying more than one object is rejected.
+            
+            **Highlighting support**
+            
+
+            HTML content may include the `<mark>` element to highlight text.
+
+            - Use the attribute data-color or background-color with one of these six approved HEX values:  
+
+              - #A8F0C6  
+
+              - #B3E5FF  
+
+              - #D6C3FF  
+
+              - #D6F5A3  
+
+              - #FFB3C6  
+
+              - #FFD0C0
+
+            - The Proofed system ignores any inline background-color attribute where data-color is also specified for the same mark tag.
+            
+          items:
+            $ref: "#/components/schemas/WorkItem"
+    WorkItem:
+      type: object
+      description: >
+        A unit of content to be edited. For `JSON` orders this represents a section (block) of the document; for file uploads (`DOCX`, `PDF`, `PPTX`, `XLSX`) a single WorkItem carries the Base64-encoded file in `content`.
+      required:
+        - content
+      properties:
+        name:
+          type: string
+          description: >
+            **Conditional.** The name of the section within the document. Used for `JSON` block content; not used for file uploads.
+          example: "Introduction"
+        type:
+          type: string
+          enum:
+            - text
+            - html
+          description: >
+            **Conditional.** For `JSON` block content, specifies the format of the section. Not used for file uploads.
+
+            - **text:** Plain text.
+
+            - **html:** HTML formatted content.
+          example: "html"
+        content:
+          type: string
+          description: >
+            **Mandatory.** The content to be edited.
+
+            - For `JSON` orders: the actual text or HTML content of the section.
+
+            - For file uploads (`DOCX`, `PDF`, `PPTX`, `XLSX`): the Base64-encoded raw bytes of the file, with no data-URI prefix. Content that is not valid Base64, or a file that cannot be read for word counting, is rejected.
+          example: "<p>Welcome to the introduction.</p>"
+    OrderResponse:
+      type: object
+      description: >
+        Response payload for a successfully submitted order.
+        Contains the idempotency identifier and Proofed's unique order ID.
+      properties:
+        idempotencyId:
+          type: string
+          format: uuid
+          description: The idempotency identifier returned with the order.
+          example: "0aa98460-7156-4e48-99b6-909f9a527229"
+        orderId:
+          type: integer
+          description: Proofed's unique identifier for the created order.
+          example: 123456
+    OrderCallback:
+      type: object
+      description: >
+        Payload sent via webhook when the API backend completes order actions (creation, completion, or cancellation).
+      required:
+        - idempotencyId
+        - orderId
+        - message
+      properties:
+        idempotencyId:
+          type: string
+          description: The idempotency identifier matching the original order submission.
+          example: "0aa98460-7156-4e48-99b6-909f9a527229"
+        orderId:
+          type: integer
+          description: The unique Proofed order identifier.
+          example: 123456
+        deadline:
+          type: string
+          format: date-time
+          description: >
+            The deadline for the order completion (applicable for Order Created).
+            Provided in ISO 8601 format (e.g. "2025-03-12T16:05:13.0000000Z").
+            The timezone is UTC+0.
+          example: "2025-03-12T16:05:13.0000000Z"
+        wordCount:
+          type: integer
+          description: >
+            The total word count of the submitted content (applicable for Order Created).
+          example: 500
+        message:
+          type: string
+          description: >
+            The updated status or details of the order. Valid values include:
+
+
+            - **Order.Created:** The order has been created.
+
+
+            - **Order.Complete:** The order has been completed (in development, not yet deployed).
+            
+            
+            - **Order.Canceled:** The order has been canceled (in development, not yet deployed).
+            
+            
+            - **Exception: [Error={error}] [InvocationId={id}]:** An issue occurred while processing the order, where `{error}` is the error description and `{id}` is the invocation identifier.
+
+
+          example: "Order.Created"
+    ErrorResponse:
+      type: object
+      description: >
+        Standard error response payload returned for unsuccessful API requests.
+      properties:
+        code:
+          type: string
+          description: A short error code identifying the type of error.
+          example: "4000"
+        field:
+          type: string
+          description: The specific field related to the error, if applicable.
+          example: "services"
+        message:
+          type: string
+          description: A detailed error message explaining the reason for the error.
+          example: "list of services not found"
+    UnauthorizedErrorResponse:
+      type: object
+      description: >
+        Error response returned when authentication fails due to invalid or missing credentials.
+      properties:
+        type:
+          type: string
+          description: A URI reference identifying the problem type.
+          example: "https://tools.ietf.org/html/rfc7235#section-3.1"
+        title:
+          type: string
+          description: A short, human-readable summary of the problem.
+          example: "Unauthorized"
+        status:
+          type: integer
+          description: The HTTP status code.
+          example: 401
+        traceId:
+          type: string
+          description: A unique identifier for tracing the request.
+          example: "00-1e76fc80edb3bb828d973775354ef43c-1bf9d9b82629839d-00"
+    InternalServerErrorResponse:
+      type: object
+      description: >
+        Error response returned when an internal server error occurs.
+    CommentItem:
+      type: object
+      description: >
+        Represents a comment associated with a specific section of content within a work item.
+      properties:
+        startPosition:
+          type: integer
+          description: The starting position of the commented section within the content (e.g., character or byte offset).
+          example: 10
+        endPosition:
+          type: integer
+          description: The ending position of the commented section within the content (e.g., character or byte offset).
+          example: 20
+        comment:
+          type: string
+          description: The text of the comment.
+          example: "Please clarify this section."
+    Order:
+      type: object
+      properties:
+        orderId:
+          type: integer
+          description: The unique identifier of the order.
+        idempotencyId:
+          type: string
+          description: The idempotency identifier of the order.
+        externalReference:
+          type: string
+          description: The unique reference provided by your system to correlate orders.
+        creationDate:
+          type: string
+          format: date-time
+          description: The date and time when the order was created, in ISO 8601 format (YYYY-MM-DDThh:mm:ss[.nnnnnnn] UTC).
+        status:
+          type: string
+          enum:
+            - Live
+            - Completed
+            - Canceled
+          description: The status of the order.
+    OrderDetail:
+      allOf:
+        - $ref: "#/components/schemas/Order"
+        - type: object
+          properties:
+            projectId:
+              type: integer
+              description: The unique identifier for the project this order belongs to.
+            batchIdentifier:
+              type: string
+              description: The batch identifier for grouping related orders.
+            purchaseOrderId:
+              type: string
+              description: The accounting purchase order identifier provided by your system. This ID will be passed through accounting processes and uniquely identifies each order against the purchase order ID in addition to the external reference.
+            commentToCustomer:
+              type: string
+              description: >
+                An optional comment from Proofed to the customer regarding the order.
+                This field is present only when non-null.
+            workItem:
+              type: array
+              items:
+                $ref: "#/components/schemas/WorkItemResponse"
+    WorkItemResponse:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the work item section (present if JSON).
+        type:
+          type: string
+          description: The type of the content (e.g., 'text' or 'html'; present if JSON).
+        content:
+          type: string
+          description: The content of the work item.
+        comments:
+          type: array
+          description: An array of comments associated with this work item.
+          items:
+            $ref: "#/components/schemas/CommentItem"
+          example:
+            - startPosition: 10
+              endPosition: 20
+              comment: "Please clarify this section."
+            - startPosition: 30
+              endPosition: 40
+              comment: "Looks good."

--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -458,7 +458,7 @@ components:
 
             - `DOCX`, `PDF`, `PPTX`, `XLSX` — a file uploaded as a Base64-encoded string in `workItem`.
 
-            The set of accepted file formats is controlled by Proofed and confirmed during onboarding; a value outside the supported set is rejected.
+            Formats not listed here will be rejected.
           example: "JSON"
         projectId:
           type: integer

--- a/customer-api/versions.json
+++ b/customer-api/versions.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "1.3.0",
+    "url": "https://raw.githubusercontent.com/Proofed/B2BCustomerDocumentation/refs/heads/main/customer-api/1.3.0.yaml"
+  },
+  {
     "version": "1.2.0",
     "url": "https://raw.githubusercontent.com/Proofed/B2BCustomerDocumentation/refs/heads/main/customer-api/1.2.0.yaml"
   },


### PR DESCRIPTION
Adds the production server entry and a new **1.3.0** version of the Customer API reference documenting Base64 binary file upload (DOCX/PDF/PPTX/XLSX) for order creation.

**Changes**
- `customer-api/1.3.0.yaml` (new) — documents `workItemFormat` values (JSON + DOCX/PDF/PPTX/XLSX), the `workItem` JSON-vs-file usage, Base64 `content`, `workItemIdentity` filename rules, validation behaviour, and adds HTML (Block JSON) + DOCX file-upload request examples. Relaxes `WorkItem.required` to `content`; fixes a typo.
- `customer-api/versions.json` — adds the `1.3.0` entry.
- `customer-api/1.2.0.yaml` — adds the Production server (`https://api.proofed.com`).

Documents PP-1931 (and the feature shipped under PP-1900).
