### PR TITLE
Customer API 1.3.0: restore full field coverage in request examples

### DIFF
--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -81,6 +81,7 @@ paths:
                   contentSubject: "Commercial Real Estate"
                   language: "en-US"
                   workItemFormat: "JSON"
+                  workItemIdentity: "Document-1"
                   projectId: 123
                   workItemStyleName: "Modern"
                   workItemStyleGuideUrl: "https://example.com/styleguide"

--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -82,6 +82,12 @@ paths:
                   language: "en-US"
                   workItemFormat: "JSON"
                   projectId: 123
+                  workItemStyleName: "Modern"
+                  workItemStyleGuideUrl: "https://example.com/styleguide"
+                  workItemStyleIdentifier: "standard-style-01"
+                  batchIdentifier: "batch-001"
+                  purchaseOrderId: "PO-12345"
+                  additionalBriefContent: "Please review the document for accuracy."
                   workItem:
                     - name: "Introduction"
                       type: "html"
@@ -99,6 +105,12 @@ paths:
                   workItemFormat: "DOCX"
                   workItemIdentity: "Document-1"
                   projectId: 123
+                  workItemStyleName: "Modern"
+                  workItemStyleGuideUrl: "https://example.com/styleguide"
+                  workItemStyleIdentifier: "standard-style-01"
+                  batchIdentifier: "batch-001"
+                  purchaseOrderId: "PO-12345"
+                  additionalBriefContent: "Please review the document for accuracy."
                   workItem:
                     - content: "UEsDBBQAAAAIAB1geVyY04HD...(Base64 of the file)...AAAA="
       responses:


### PR DESCRIPTION
Restores full field coverage in the 1.3.0 create-order request examples.

When the named examples (`jsonBlockOrder`, `fileUploadOrder`) were introduced in 1.3.0, Redoc began rendering them instead of the auto-generated full-schema sample — which dropped the optional fields the 1.2.0 sample used to show. This adds them back so both examples are comprehensive again, while keeping the JSON-vs-file distinction and the Base64 example.

**Changes (examples only — no schema changes):**
- Both examples now include `workItemStyleName`, `workItemStyleGuideUrl`, `workItemStyleIdentifier`, `batchIdentifier`, `purchaseOrderId`, `additionalBriefContent`.
- `workItemIdentity` added to the JSON example too (optional for JSON; gives full field parity across both examples).
