### PR TITLE
Docs: clarify Get Order by ID content field is Base64 for file-based orders

### DIFF
--- a/customer-api/1.3.0.yaml
+++ b/customer-api/1.3.0.yaml
@@ -759,19 +759,28 @@ components:
                 $ref: "#/components/schemas/WorkItemResponse"
     WorkItemResponse:
       type: object
+      description: >
+        A unit of returned content. For `JSON` orders each work item is a decoded
+        section (block) of the document; for file-based orders a single work item
+        carries the Base64-encoded file in `content`.
       properties:
         name:
           type: string
-          description: The name of the work item section (present if JSON).
+          description: The name of the work item section. Populated for `JSON` orders only; not present for file-based orders.
         type:
           type: string
-          description: The type of the content (e.g., 'text' or 'html'; present if JSON).
+          description: The type of the section content (e.g. 'text' or 'html'). Populated for `JSON` orders only; not present for file-based orders.
         content:
           type: string
-          description: The content of the work item.
+          description: >
+            The content of the work item. The format depends on how the order was originally submitted:
+
+            - **`JSON` (Block JSON) orders:** the decoded text or HTML content of the section.
+
+            - **File-based orders (`DOCX`, `PDF`, `PPTX`, `XLSX`):** the Base64-encoded raw bytes of the file, with no data-URI prefix.
         comments:
           type: array
-          description: An array of comments associated with this work item.
+          description: An array of comments associated with this work item. Not present for file-based orders.
           items:
             $ref: "#/components/schemas/CommentItem"
           example:


### PR DESCRIPTION
Clarifies the `Get Order by ID` response (`GET /clientAPIservice/orders/{id}`) in the Customer API reference (`customer-api/1.3.0.yaml`).

**What changed** — `WorkItemResponse` schema only:
- `content` — now documents both modes: JSON (Block JSON) orders return the decoded section content; file-based orders (DOCX, PDF, PPTX, XLSX) return the **Base64-encoded raw file bytes** (no data-URI prefix).
- `name` / `type` — clarified as populated for JSON orders only.
- `comments` — noted as not present for file-based orders.
- Added a short object-level description to `WorkItemResponse`.

Behaviour confirmed against `ApplicationServices/ExternalIntegration/Service/ClientAPI/Controllers/OrdersController.cs` (GET-by-id handler). No other part of the spec changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)